### PR TITLE
refactor: restore _read_stream with modifications to read entire line

### DIFF
--- a/_read_stream.c
+++ b/_read_stream.c
@@ -19,25 +19,12 @@ char *_read_stream()
 		exit(EXIT_FAILURE);
 	}
 
-	while (1)
+	while ((ch = getchar()) != EOF)
 	{
-		ch = getchar();
-		if (ch == EOF)
-		{
-			free(line);
-			exit(EXIT_SUCCESS);
-		}
+		if (ch == ' ')
+			continue;
 
-		if (ch == '\n')
-		{
-			line[i] = '\0';
-			return line;
-		}
-		else
-		{
-			line[i] = ch;
-		}
-
+		line[i] = ch;
 		i++;
 
 		if (i >= bufsize)
@@ -52,4 +39,7 @@ char *_read_stream()
 			}
 		}
 	}
+
+	line[i] = '\0';
+	return line;
 }


### PR DESCRIPTION
I restored the use of _read_stream function to handle the case where input line was too long. This needed to be handled in such a way as to ignore empty spaces in the input.