### PR TITLE
refactor: modify _execute_args to use struct instead of two arrays

### DIFF
--- a/_execute_args.c
+++ b/_execute_args.c
@@ -25,25 +25,19 @@
  */
 int _execute_args(char **args)
 {
-	char *builtin_funcs_list[] = {"cd", "help", "env"};
 
-	int (*builtin_funcs[])(char **) = {
-	    &shell_cd,
-	    &shell_help,
-	    &shell_env};
+	BuiltinFunction builtin_funcs[] = {
+	    {"cd", &shell_cd},
+	    {"help", &shell_help},
+	    {"env", &shell_env}};
 
 	unsigned int i;
 
-	if (args[0] == NULL)
+	for (i = 0; i < sizeof(builtin_funcs) / sizeof(BuiltinFunction); i++)
 	{
-		return (-1);
-	}
-
-	for (i = 0; i < sizeof(builtin_funcs_list) / sizeof(char *); i++)
-	{
-		if (strcmp(args[0], builtin_funcs_list[i]) == 0)
+		if (strcmp(args[0], builtin_funcs[i].name) == 0)
 		{
-			return ((*builtin_funcs[i])(args));
+			return (builtin_funcs[i].func(args));
 		}
 	}
 

--- a/shell.h
+++ b/shell.h
@@ -25,7 +25,11 @@ int _execute_args(char **args);
 char *get_filepath(char *command);
 const char *get_filename(const char *path);
 
-extern char *builtin_func_list[];
+typedef struct
+{
+	const char *name;
+	int (*func)(char **);
+} BuiltinFunction;
 
 /* Functin declarations for builtin simple shell commands*/
 int shell_cd(char **args);


### PR DESCRIPTION
I updated the _execute_args function to use an array of structs instead of two arrays.